### PR TITLE
Change interpreter to "/usr/bin/env node"

### DIFF
--- a/git-review.js
+++ b/git-review.js
@@ -1,3 +1,3 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 var gitReview = require('./lib/git-review');
 module.exports = gitReview;


### PR DESCRIPTION
Native install of node.js on GNU/Linux are placed under `/usr/bin/node`.

Most programs sets the interpreter like this.
